### PR TITLE
Modify Vite config to build for production server

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: 'https://classified.code.sydney/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Describe the Changes
The Vite config needed to be told where the site will be hosted. At the moment is being tested at https://classified.code.sydney

## Did you test this ticket on all browsers?
No. Config for server only.