### PR TITLE
CA-86 Backend: Users Ability to Hide Profile (From Search and GET /api/v1/profile/<id> Endpoint)

### DIFF
--- a/client/src/pages/UserProfile.jsx
+++ b/client/src/pages/UserProfile.jsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { useParams } from 'react-router-dom'
 import { useSelector } from 'react-redux'
+import { toast } from 'react-hot-toast'
 import { useAppDispatch } from '../store.js'
 import { getUserProfile } from '../features/users/usersAction.js'
 
@@ -12,7 +13,15 @@ const UserProfile = () => {
   const { userProfile } = useSelector(state => state.users)
 
   useEffect(() => {
-    dispatch(getUserProfile({ userId }))
+    const fetchUserProfile = async () => {
+      const response = await dispatch(getUserProfile({ userId }))
+
+      if (response.error) {
+        toast.error('User Not Found')
+      }
+    }
+
+    fetchUserProfile()
   }, [userId])
 
   return (

--- a/server/src/controllers/UserController.js
+++ b/server/src/controllers/UserController.js
@@ -263,6 +263,13 @@ const getUserProfile = catchAsync(async (req, res) => {
 
   const userDetails = await UserService.getUserProfile(userId, isAuthenticated)
 
+  if (!userDetails) {
+    return res.status(404).json({
+      status: 'Error',
+      message: 'User not found',
+    })
+  }
+
   res.status(200).json({
     status: 'OK',
     message: 'User retrieved successfully',

--- a/server/src/migration/userMigration.js
+++ b/server/src/migration/userMigration.js
@@ -89,6 +89,7 @@ const generateUser = async () => ({
   },
   isAutomated: true,
   isOfficer: false,
+  displayProfile: true,
 })
 
 // Function to insert a batch of users into the database

--- a/server/src/migration/userMigration.js
+++ b/server/src/migration/userMigration.js
@@ -89,7 +89,7 @@ const generateUser = async () => ({
   },
   isAutomated: true,
   isOfficer: false,
-  displayProfile: true,
+  hideProfile: false,
 })
 
 // Function to insert a batch of users into the database

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -123,6 +123,10 @@ const UserSchema = new Schema(
       type: Boolean,
       default: false,
     },
+    displayProfile: {
+      type: Boolean,
+      default: true,
+    },
   },
   {
     timestamps: true,

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -123,9 +123,9 @@ const UserSchema = new Schema(
       type: Boolean,
       default: false,
     },
-    displayProfile: {
+    hideProfile: {
       type: Boolean,
-      default: true,
+      default: false,
     },
   },
   {

--- a/server/src/services/UserService.js
+++ b/server/src/services/UserService.js
@@ -84,11 +84,11 @@ const getUsers = async (
   isAuthenticated,
 ) => {
   let matchCriteria = {
-    hideProfile: false,
+    $and: [{ hideProfile: false }],
   }
 
   if (searchQuery.length >= 3) {
-    matchCriteria = {
+    matchCriteria.$and.push({
       $or: [
         { firstName: { $regex: searchQuery, $options: 'i' } },
         { lastName: { $regex: searchQuery, $options: 'i' } },
@@ -102,7 +102,10 @@ const getUsers = async (
         { 'service.serviceName': { $regex: searchQuery, $options: 'i' } },
         { 'service.serviceUrl': { $regex: searchQuery, $options: 'i' } },
       ],
-    }
+    })
+  } else {
+    // If no searchQuery, just ensure hideProfile: false is the only criteria
+    matchCriteria = { hideProfile: false }
   }
 
   let skip = (page - 1) * limit
@@ -119,6 +122,8 @@ const getUsers = async (
       : users.map(userDetails =>
           constructUnauthenticatedUsersResponse(userDetails),
         )
+
+    console.log('users', users)
 
     return {
       data: usersResponse,

--- a/server/src/services/UserService.js
+++ b/server/src/services/UserService.js
@@ -1,23 +1,26 @@
 const User = require('../models/User')
 
-// This is breaking my build. If you are a user without these fields -> will break on their own page.
 const constructUnauthenticatedUsersResponse = user => {
+  const safeUser = user || {}
+  const safeEducation = safeUser.education || {}
+  const safeService = safeUser.service || {}
+
   return {
-    id: user.id,
-    firstName: user.firstName,
-    lastName: user.lastName,
-    fullName: user.fullName,
-    state: user.state,
-    alumniProfilePicture: user.alumniProfilePicture,
+    id: safeUser.id || '',
+    firstName: safeUser.firstName || '',
+    lastName: safeUser.lastName || '',
+    fullName: safeUser.fullName || '',
+    state: safeUser.state || '',
+    alumniProfilePicture: safeUser.alumniProfilePicture || '',
     education: {
-      course: user.education.course,
-      college: user.education.college,
-      yearGraduated: user.education.yearGraduated,
+      course: safeEducation.course || '',
+      college: safeEducation.college || '',
+      yearGraduated: safeEducation.yearGraduated || '',
     },
     service: {
-      serviceName: user.service.serviceName,
-      serviceLogo: user.service.serviceLogo,
-      serviceUrl: user.service.serviceUrl,
+      serviceName: safeService.serviceName || '',
+      serviceLogo: safeService.serviceLogo || '',
+      serviceUrl: safeService.serviceUrl || '',
     },
   }
 }
@@ -122,8 +125,6 @@ const getUsers = async (
       : users.map(userDetails =>
           constructUnauthenticatedUsersResponse(userDetails),
         )
-
-    console.log('users', users)
 
     return {
       data: usersResponse,

--- a/server/src/services/UserService.js
+++ b/server/src/services/UserService.js
@@ -37,12 +37,6 @@ const getUserById = async id => {
   return userObject
 }
 
-const hasNestedFieldsUpdated = (nestedObject, requiredFields) => {
-  return requiredFields.every(
-    field => nestedObject[field] !== undefined && nestedObject[field] !== null,
-  )
-}
-
 const updateAlumniProfile = async (userId, profileUpdates) => {
   const updatedUser = await User.findByIdAndUpdate(
     userId,
@@ -89,7 +83,10 @@ const getUsers = async (
   { searchQuery = '', page = 1, limit = 10 },
   isAuthenticated,
 ) => {
-  let matchCriteria = {}
+  let matchCriteria = {
+    hideProfile: false,
+  }
+
   if (searchQuery.length >= 3) {
     matchCriteria = {
       $or: [

--- a/server/src/services/UserService.js
+++ b/server/src/services/UserService.js
@@ -136,6 +136,13 @@ const getUsers = async (
 }
 
 const getUserProfile = async (userId, isAuthenticated) => {
+  // check that the user has not set their profile to be hidden
+  const user = await User.findById(userId).exec()
+
+  if (!user || user.hideProfile) {
+    return null
+  }
+
   const userDetails = await getUserById(userId)
 
   // based on the authentication status, filter out some fields


### PR DESCRIPTION
## Describe the Changes
Ability for the user to be able to update their profile to hide their profile. If they switch the new flag called `hideProfile` is true it means that they will be hidden from the search and also the GET /api/v1/profile/<id> will also result in a 404.

## Screenshots:
<img width="435" alt="image" src="https://github.com/codesydney/classified-ads-app-for-good/assets/92339996/30905785-4c74-4211-b677-086f20d72220">


## Related Ticket
https://github.com/codesydney/classified-ads-app-for-good/issues/86

## Did you test this ticket on all browsers?
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Internet Explorer