### PR TITLE
Issue-98-small-UI-fixes

### DIFF
--- a/client/src/components/search/UserDetails.jsx
+++ b/client/src/components/search/UserDetails.jsx
@@ -29,7 +29,7 @@ const UserDetails = ({ userProfile }) => {
         )}
 
         <div className=" mt-4">
-          <h2 className="font-semibold">MyStory: </h2>
+          <h2 className="font-semibold">My Story: </h2>
           <p>{userProfile?.story}</p>
         </div>
 
@@ -44,11 +44,6 @@ const UserDetails = ({ userProfile }) => {
         {userProfile?.service && (
           <div className="mt-[10px] w-[100%] flex flex-wrap mb-[16px]">
             <div className=" flex flex-col gap-2">
-              <img
-                className=" w-[35px] h-[35px] rounded-full"
-                src={userProfile?.service?.serviceLogoUrl || defaultUserLogo}
-                alt={userProfile?.service?.serviceName}
-              />
               <div className=" break-words hyphens-auto whitespace-pre break-all">
                 <a
                   href={`${userProfile?.service?.serviceUrl}`}


### PR DESCRIPTION
## Describe the Changes
- Small fixes, added a space between My Story, and removed the service logo as it's not needed.

## Screenshots:
![updated-user-profile-info-mobile-1](https://github.com/codesydney/classified-ads-app-for-good/assets/60167200/6161e132-9334-456b-a934-e8d741881cb4)


## Related Ticket
https://github.com/codesydney/classified-ads-app-for-good/issues/98

## E2E Tests Cases
- Public view (user), from the main page click view profile, then the user will land on the profile view page.
- Private view (officer), login then from the main page click view profile, then will land on the full profile view page.

## Advice for Reviewers & Testing Notes
N/A

## Did you test this ticket on all browsers?
[ ✔] Chrome
[ ✔] Firefox
[ ✔] Edge
[ ❌] Internet Explorer