### PR TITLE
CA-111 Consent Caveat

### DIFF
--- a/client/src/components/Consent.jsx
+++ b/client/src/components/Consent.jsx
@@ -1,6 +1,6 @@
 const Consent = () => {
   return (
-    <p>
+    <p className="text-[11px] text-justify">
       Signing up and using the service means agreeing with the below consent.
       Consent clause 'By providing your personal information, you consent to its
       use for any purpose of the USTAA including publishing photos and

--- a/client/src/components/Consent.jsx
+++ b/client/src/components/Consent.jsx
@@ -1,0 +1,12 @@
+const Consent = () => {
+  return (
+    <p>
+      Signing up and using the service means agreeing with the below consent.
+      Consent clause 'By providing your personal information, you consent to its
+      use for any purpose of the USTAA including publishing photos and
+      non-personally identifiable information on USTAA's social media pages.
+    </p>
+  )
+}
+
+export default Consent

--- a/client/src/components/profile/ProfileLayout.jsx
+++ b/client/src/components/profile/ProfileLayout.jsx
@@ -1,5 +1,6 @@
 import ProfileNav from './ProfileNav'
 import Header from './Header'
+import Consent from '../Consent.jsx'
 import { Outlet } from 'react-router-dom'
 
 const ProfileLayout = () => {
@@ -13,6 +14,10 @@ const ProfileLayout = () => {
           <Header />
           <div className="bg-white shadow-md rounded-md p-4">
             <Outlet />
+          </div>
+
+          <div className="mt-[25px]">
+            <Consent />
           </div>
         </div>
       </div>

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,4 +1,5 @@
 import LoginForm from '../components/LoginForm.jsx'
+import Consent from '../components/Consent.jsx'
 import { Link } from 'react-router-dom'
 import LoginHeroPic from '../assets/ust-login.jpeg'
 
@@ -27,6 +28,10 @@ const Login = () => {
             here
           </Link>
         </p>
+
+        <div className="w-full px-6 sm:px-8 md:px-16 lg:px-32 xl:px-40 mt-[25px]">
+          <Consent />
+        </div>
       </div>
     </div>
   )

--- a/client/src/pages/Signup.jsx
+++ b/client/src/pages/Signup.jsx
@@ -1,4 +1,5 @@
 import SignUpForm from '../components/SignUpForm'
+import Consent from '../components/Consent'
 import { Link } from 'react-router-dom'
 import SignUpHeroPic from '../assets/ust-sign-up.jpeg'
 
@@ -27,6 +28,10 @@ const Signup = () => {
             here
           </Link>
         </p>
+
+        <div className="w-full px-6 sm:px-8 md:px-16 lg:px-32 xl:px-40 mt-[25px]">
+          <Consent />
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Describe the Changes
Added the short consent caveat message to the Sign Up, Login and Alumni profile page.

## Screenshots:
Sign up
![image](https://github.com/codesydney/classified-ads-app-for-good/assets/92339996/a86f7030-00bb-48b1-85f8-96b22c965c50)

Login
![image](https://github.com/codesydney/classified-ads-app-for-good/assets/92339996/b9d23fa0-6e57-4d69-854b-87a6ec93e2a9)

Alumni Profile
![image](https://github.com/codesydney/classified-ads-app-for-good/assets/92339996/389cb93b-15da-4e06-8fcc-3afaa487857f)

## Related Ticket
https://github.com/codesydney/classified-ads-app-for-good/issues/111

## Did you test this ticket on all browsers?
- [x] Chrome