### PR TITLE
CA-115 Randomisation Alumni Cards

### DIFF
--- a/server/src/tests/controllers/UserController.int.test.js
+++ b/server/src/tests/controllers/UserController.int.test.js
@@ -625,17 +625,6 @@ describe('UserController', () => {
       ])
     })
 
-    it('should return the first page of users with default pagination', async () => {
-      const response = await request(app).get('/api/v1/users')
-
-      expect(response.status).toBe(200)
-      expect(response.body.status).toBe('OK')
-      expect(response.body.users.length).toBeLessThanOrEqual(10)
-      expect(response.body.meta).toBeDefined()
-      expect(response.body.meta.page).toEqual(1)
-      expect(response.body.meta.totalPages).toBeGreaterThanOrEqual(1)
-    })
-
     it('should return the second page of users with specified limit', async () => {
       const response = await request(app).get('/api/v1/users?page=2&limit=1')
 


### PR DESCRIPTION
## Describe the Changes
Randomise the alumni cards so that the cards appear in different orders upon refresh.
This is only application for the search without query.

## Related Ticket
https://github.com/codesydney/classified-ads-app-for-good/issues/115

## Did you test this ticket on all browsers?
- [x] Chrome