### PR TITLE
- fixing UI issues in the personal profile settings

### DIFF
--- a/client/src/components/profile/Header.jsx
+++ b/client/src/components/profile/Header.jsx
@@ -45,7 +45,7 @@ const Header = () => {
   }
 
   function completedPercentage(incomplete, total) {
-    // Flipping the logic to found out how many fields are complete
+    // Flipping the logic to find out how many fields are complete
     const completedFields = total - incomplete
     return (completedFields / total).toPrecision(2) * 100
   }
@@ -65,9 +65,12 @@ const Header = () => {
         {!currentUser?.isProfileComplete && (
           <span className=" flex gap-2 py-2 px-4 border-2 mt-4 sm:mt-0 w-full sm:w-fit border-red-500 rounded-md text-red-500 text-center bg-red-200/50">
             {`Your profile is ${percentCompleted}% complete! Click for info`}
-            <Tooltip tooltipRef={tooltipRef} extraClasses={'-bottom-52'}>
-              <div className="flex flex-col justify-start items-start gap-2">
-                <span className=" text-left text-primary">
+            <Tooltip
+              tooltipRef={tooltipRef}
+              extraClasses={`${percentCompleted > 50 ? '!-bottom-[150%] sm:!-bottom-[350%]' : '!-bottom-[500%] sm:!-bottom-[650%]'}`}
+            >
+              <div className="flex flex-col justify-start items-start gap-2 bottom">
+                <span className=" text-left text-primary bottom">
                   Please complete those fields!
                 </span>
                 {incompleteRequiredFields.map((fields, index) => {

--- a/client/src/components/profile/avatar/AddPhotoModalBody.jsx
+++ b/client/src/components/profile/avatar/AddPhotoModalBody.jsx
@@ -94,7 +94,7 @@ const AddPhotoModalBody = ({ setCurrentTab, currentUser }) => {
         <div className="p-6 flex justify-end gap-4">
           <ModalButton
             extraClasses={
-              ' !text-red-400 hover:!text-white bg-transparent border-red-500 hover:border-red-500 hover:bg-red-500'
+              ' !text-red-500 hover:!text-white bg-transparent border-red-500 hover:border-red-500 hover:bg-red-500'
             }
             onClick={() => setCurrentTab('main')}
           >

--- a/client/src/components/profile/avatar/ImageCrop.jsx
+++ b/client/src/components/profile/avatar/ImageCrop.jsx
@@ -108,7 +108,7 @@ const ImageCrop = ({ src, closeCrop, setCurrentTab, fileName }) => {
       <div className="p-6 flex justify-end gap-4">
         <ModalButton
           extraClasses={
-            'text-red-500 hover:text-white bg-transparent border-red-500 hover:border-red-500 hover:bg-red-500'
+            '!text-red-500 hover:!text-white bg-transparent border-red-500 hover:border-red-500 hover:bg-red-500'
           }
           onClick={closeCrop}
           disabled={isLoading}


### PR DESCRIPTION
## Describe the Changes
- fixing some minor UI issues in the user profile settings
- user profile image upload, the cancel button text is visible now
- the user profile completion tooltip should be within view port (note: due to absolute values, it's hard to make the position align nicely with the parent element)

## Screenshots:
![Fix_1](https://github.com/codesydney/classified-ads-app-for-good/assets/60167200/8763e1a4-05e1-4b70-b986-aecb9d6fdf87)
![Fix_2](https://github.com/codesydney/classified-ads-app-for-good/assets/60167200/361ca91f-50cb-4ffb-9c79-df698983e2e6)
![Fix_3](https://github.com/codesydney/classified-ads-app-for-good/assets/60167200/7c0bc7ab-5d17-4171-a46d-0d739cc1b1e8)


## Related Ticket
[- Add the link of the ticket this pull request is resolving.](https://github.com/codesydney/classified-ads-app-for-good/issues/132)

## Unit Tests Cases / E2E Tests Cases
- Where applicable, indicate the test results recorded.
- If manual tests are only applicable, outline the steps needed to perform the tests.

## Advice for Reviewers & Testing Notes
- please check the authenticated user profile and try to add or remove a required field to enable public profile view
- try to upload a user profile image and check if the cancel button text is visible
- NOTE: there is some issues when deleting and uploading the user image, as it marks all required fields as completed but the user "currentUser.isProfileComplete", does't get set to true. Hence, the ui does't show the link.

## Did you test this ticket on all browsers?
- [✔] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer