### PR TITLE
CA-142 Include Year Graduated in Search Criteria for Enhanced Alumni Search Functionality

### DIFF
--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -157,6 +157,12 @@ UserSchema.virtual('fullName').get(function () {
   return `${this.firstName} ${this.lastName}`
 })
 
+UserSchema.virtual('education.yearGraduatedStr').get(function () {
+  return this.education.yearGraduated
+    ? this.education.yearGraduated.toString()
+    : ''
+})
+
 UserSchema.pre('save', function (next) {
   if (!this.isModified('password')) return next()
 
@@ -193,6 +199,7 @@ UserSchema.index({
   story: 'text',
   'education.course': 'text',
   'education.college': 'text',
+  'education.yearGraduated': 'text',
   'service.serviceName': 'text',
   'service.serviceDescription': 'text',
   'service.serviceUrl': 'text',

--- a/server/src/services/UserService.js
+++ b/server/src/services/UserService.js
@@ -153,25 +153,32 @@ const getUsers = async (
   }
 
   if (searchQuery.length >= 3) {
-    matchCriteria.$and.push({
-      $or: [
-        { firstName: { $regex: searchQuery, $options: 'i' } },
-        { lastName: { $regex: searchQuery, $options: 'i' } },
-        { email: { $regex: searchQuery, $options: 'i' } },
-        { state: { $regex: searchQuery, $options: 'i' } },
-        { suburb: { $regex: searchQuery, $options: 'i' } },
-        { postcode: { $regex: searchQuery, $options: 'i' } },
-        { facebookName: { $regex: searchQuery, $options: 'i' } },
-        { story: { $regex: searchQuery, $options: 'i' } },
-        { 'education.course': { $regex: searchQuery, $options: 'i' } },
-        { 'education.college': { $regex: searchQuery, $options: 'i' } },
-        { 'service.serviceName': { $regex: searchQuery, $options: 'i' } },
-        {
-          'service.serviceDescription': { $regex: searchQuery, $options: 'i' },
-        },
-        { 'service.serviceUrl': { $regex: searchQuery, $options: 'i' } },
-      ],
-    })
+    const numericSearchQuery = parseInt(searchQuery, 10)
+    const isNumericSearch = !isNaN(numericSearchQuery)
+
+    const searchConditions = [
+      { firstName: { $regex: searchQuery, $options: 'i' } },
+      { lastName: { $regex: searchQuery, $options: 'i' } },
+      { email: { $regex: searchQuery, $options: 'i' } },
+      { state: { $regex: searchQuery, $options: 'i' } },
+      { suburb: { $regex: searchQuery, $options: 'i' } },
+      { postcode: { $regex: searchQuery, $options: 'i' } },
+      { facebookName: { $regex: searchQuery, $options: 'i' } },
+      { story: { $regex: searchQuery, $options: 'i' } },
+      { 'education.course': { $regex: searchQuery, $options: 'i' } },
+      { 'education.college': { $regex: searchQuery, $options: 'i' } },
+      { 'service.serviceName': { $regex: searchQuery, $options: 'i' } },
+      {
+        'service.serviceDescription': { $regex: searchQuery, $options: 'i' },
+      },
+      { 'service.serviceUrl': { $regex: searchQuery, $options: 'i' } },
+    ]
+
+    if (isNumericSearch) {
+      searchConditions.push({ 'education.yearGraduated': numericSearchQuery })
+    }
+
+    matchCriteria.$and.push({ $or: searchConditions })
   } else {
     // If no searchQuery, just ensure hideProfile: false is the only criteria
     matchCriteria = {


### PR DESCRIPTION
## Describe the Changes
This PR introduces the ability to include 'Year Graduated' in the search criteria within our alumni database. Previously, the search functionality did not cater to queries based on the graduation year, limiting the specificity and utility of search results for users looking to find alumni from particular graduating years.

## Screenshots:
![image](https://github.com/codesydney/classified-ads-app-for-good/assets/92339996/cd557f68-0fe4-4940-8899-dd40c0ebaf4f)


## Related Ticket
https://github.com/codesydney/classified-ads-app-for-good/issues/142

## Did you test this ticket on all browsers?
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Internet Explorer